### PR TITLE
Ingore resources in kube-system namespace

### DIFF
--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -229,6 +229,10 @@ func (o *Options) Run(f cmdutil.Factory, resourceTypes string) error {
 	}
 
 	if err := r.Visit(func(info *resource.Info, err error) error {
+		if info.Namespace == metav1.NamespaceSystem {
+			return nil // ignore resources in kube-system namespace
+		}
+
 		switch kind := info.Object.GetObjectKind().GroupVersionKind().Kind; kind {
 		case kindConfigMap:
 			if _, ok := usedCms[info.Name]; ok {


### PR DESCRIPTION
Details: https://github.com/micnncim/kubectl-prune/issues/9

With `--all-namespaces`, it can delete resources in `kube-system` namespace, which is scary. This PR makes it ignore resources in `kube-system` namespace for now. In the future, a flag to change the behavior may be added.