### PR TITLE
Add HPA support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,13 @@ Supported resources:
 - [x] Pods (whose status is not `Running`)
 - [x] PersistentVolumeClaim (not used in any Pods)
 - [x] PodDisruptionBudgets (not targeting any Pods)
-- [ ] HorizontalPodAutoscalers
+- [x] HorizontalPodAutoscalers (not targeting any resources)
 
 ## Installation
+
+Download precompiled binaries from [GitHub Releases](https://github.com/micnncim/kubectl-prune/releases).
+
+If you want to build a binary from source:
 
 ```
 $ GO111MODULE=on go get github.com/micnncim/kubectl-prune/cmd/kubectl-prune
@@ -110,6 +114,7 @@ Delete unused resources. Supported resources:
 - Pods (whose status is not Running)
 - PersistentVolumeClaim (not used in any Pods)
 - PodDisruptionBudgets (not targeting any Pods)
+- HorizontalPodAutoscalers (not targeting any resources)
 
 Usage:
   kubectl prune RESOURCE_TYPE [flags]

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -8,7 +9,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/cli-runtime/pkg/resource"
+	cliresource "k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -61,7 +62,7 @@ type Options struct {
 	printObj func(obj runtime.Object) error
 
 	determiner *determiner.Determiner
-	result     *resource.Result
+	result     *cliresource.Result
 
 	genericclioptions.IOStreams
 }
@@ -92,7 +93,7 @@ func NewCmdPrune(streams genericclioptions.IOStreams) *cobra.Command {
 
 			cmdutil.CheckErr(o.Validate(args))
 			cmdutil.CheckErr(o.Complete(f, args, cmd))
-			cmdutil.CheckErr(o.Run(f))
+			cmdutil.CheckErr(o.Run(context.Background(), f))
 		},
 	}
 
@@ -130,11 +131,17 @@ func (o *Options) Complete(f cmdutil.Factory, args []string, cmd *cobra.Command)
 	if err != nil {
 		return
 	}
+	dynamicClient, err := f.DynamicClient()
+	if err != nil {
+		return
+	}
+
 	namespace := o.namespace
 	if o.allNamespaces {
 		namespace = metav1.NamespaceAll
 	}
-	o.determiner, err = determiner.New(clientset, o.result, namespace)
+
+	o.determiner, err = determiner.New(clientset, dynamicClient, o.result, namespace)
 	if err != nil {
 		return
 	}
@@ -182,13 +189,13 @@ func (o *Options) Validate(args []string) error {
 	return nil
 }
 
-func (o *Options) Run(f cmdutil.Factory) error {
-	if err := o.result.Visit(func(info *resource.Info, err error) error {
+func (o *Options) Run(ctx context.Context, f cmdutil.Factory) error {
+	if err := o.result.Visit(func(info *cliresource.Info, err error) error {
 		if info.Namespace == metav1.NamespaceSystem {
 			return nil // ignore resources in kube-system namespace
 		}
 
-		prune, err := o.determiner.DeterminePrune(info)
+		prune, err := o.determiner.DeterminePrune(ctx, info)
 		if err != nil {
 			return err
 		}
@@ -201,7 +208,7 @@ func (o *Options) Run(f cmdutil.Factory) error {
 			return nil // skip prune
 		}
 
-		_, err = resource.
+		_, err = cliresource.
 			NewHelper(info.Client, info.Mapping).
 			DryRun(o.dryRunStrategy == cmdutil.DryRunServer).
 			DeleteWithOptions(info.Namespace, info.Name, &metav1.DeleteOptions{})

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -40,6 +40,7 @@ Delete unused resources. Supported resources:
 - Pods (whose status is not Running)
 - PersistentVolumeClaim (not used in any Pods)
 - PodDisruptionBudgets (not targeting any Pods)
+- HorizontalPodAutoscalers (not targeting any resources)
 `
 
 	// printedOperationTypePrune is used when printer outputs the result of operations.

--- a/pkg/cmd/cmd_test.go
+++ b/pkg/cmd/cmd_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"testing"
@@ -116,7 +117,7 @@ func TestOptions_Run(t *testing.T) {
 				return
 			}
 
-			if err := o.Run(tf); (err != nil) != tt.wantErr {
+			if err := o.Run(context.Background(), tf); (err != nil) != tt.wantErr {
 				t.Errorf("Options.Run() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}

--- a/pkg/determiner/determiner_test.go
+++ b/pkg/determiner/determiner_test.go
@@ -1,6 +1,7 @@
 package determiner
 
 import (
+	"context"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -212,7 +213,7 @@ func Test_determiner_determinePrune(t *testing.T) {
 				Pods:                       tt.fields.pods,
 			}
 
-			got, err := d.DeterminePrune(tt.args.info)
+			got, err := d.DeterminePrune(context.Background(), tt.args.info)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("determiner.determinePrune() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -3,29 +3,38 @@ package resource
 import (
 	"context"
 
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/resource"
 	cliresource "k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 )
 
 type Client interface {
 	ListPods(ctx context.Context, namespace string) ([]*corev1.Pod, error)
 	ListServiceAccounts(ctx context.Context, namespace string) ([]*corev1.ServiceAccount, error)
+	FindScaleTargetRefObject(ctx context.Context, objectRef *autoscalingv1.CrossVersionObjectReference, namespace string) (bool, error)
 }
 
 type client struct {
-	clientset *kubernetes.Clientset
+	clientset     *kubernetes.Clientset
+	dynamicClient dynamic.Interface
 }
 
 // Guarantee *client implements Client.
 var _ Client = (*client)(nil)
 
-func NewClient(clientset *kubernetes.Clientset) Client {
+func NewClient(clientset *kubernetes.Clientset, dynamicClient dynamic.Interface) Client {
 	return &client{
-		clientset: clientset,
+		clientset:     clientset,
+		dynamicClient: dynamicClient,
 	}
 }
 
@@ -52,7 +61,27 @@ func (c *client) ListServiceAccounts(ctx context.Context, namespace string) ([]*
 	return sas, nil
 }
 
-func InfoToPod(info *cliresource.Info) (*corev1.Pod, error) {
+func (c *client) FindScaleTargetRefObject(ctx context.Context, objectRef *autoscalingv1.CrossVersionObjectReference, namespace string) (bool, error) {
+	gv, err := schema.ParseGroupVersion(objectRef.APIVersion)
+	if err != nil {
+		return false, err
+	}
+
+	gvk := gv.WithKind(objectRef.Kind)
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+
+	_, err = c.dynamicClient.Resource(gvr).Namespace(namespace).Get(ctx, objectRef.Name, metav1.GetOptions{})
+	switch {
+	case err == nil:
+		return true, nil
+	case errors.IsNotFound(err):
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+func InfoToPod(info *resource.Info) (*corev1.Pod, error) {
 	var pod corev1.Pod
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(
 		info.Object.(runtime.Unstructured).UnstructuredContent(),
@@ -74,6 +103,18 @@ func InfoToPodDisruptionBudget(info *cliresource.Info) (*policyv1beta1.PodDisrup
 	}
 
 	return &pdb, nil
+}
+
+func InfoToHorizontalPodAutoscaler(info *resource.Info) (*autoscalingv1.HorizontalPodAutoscaler, error) {
+	var hpa autoscalingv1.HorizontalPodAutoscaler
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(
+		info.Object.(runtime.Unstructured).UnstructuredContent(),
+		&hpa,
+	); err != nil {
+		return nil, err
+	}
+
+	return &hpa, nil
 }
 
 func PodListToPods(podList *corev1.PodList) []*corev1.Pod {


### PR DESCRIPTION
## What

Added support for HorizontalPodAutoscaler.

```console
$ cat <<EOF | kubectl apply -f -
apiVersion: autoscaling/v1
kind: HorizontalPodAutoscaler
metadata:
  name: nginx
spec:
  maxReplicas: 10
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: nginx
  targetCPUUtilizationPercentage: 30
EOF

$ kubectl get deploy
No resources found in default namespace.

$ kubectl prune hpa
horizontalpodautoscaler.autoscaling/nginx deleted
```