### PR TITLE
Add support of label selector and field selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Flags:
       --cluster string                 The name of the kubeconfig cluster to use
       --context string                 The name of the kubeconfig context to use
       --dry-run string[="unchanged"]   Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource. (default "none")
+      --field-selector string          Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.
   -h, --help                           help for kubectl
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
   -i, --interactive                    If true, a prompt asks whether resources can be deleted
@@ -168,6 +169,7 @@ Flags:
   -o, --output string                  Output format. One of: json|yaml|name|go-template|go-template-file|template|templatefile|jsonpath|jsonpath-as-json|jsonpath-file.
   -q, --quiet                          If true, no output is produced
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -l, --selector string                Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
   -s, --server string                  The address and port of the Kubernetes API server
       --template string                Template string or path to template file to use when -o=go-template, -o=go-template-file. The template format is golang templates [http://golang.org/pkg/text/template/#pkg-overview].
       --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -59,6 +59,8 @@ type Options struct {
 	namespace     string
 	allNamespaces bool
 	chunkSize     int64
+	labelSelector string
+	fieldSelector string
 
 	quiet       bool
 	interactive bool
@@ -109,7 +111,10 @@ func NewCmdPrune(streams genericclioptions.IOStreams) *cobra.Command {
 	o.printFlags.AddFlags(cmd)
 
 	cmdutil.AddDryRunFlag(cmd)
+
 	cmd.Flags().BoolVarP(&o.allNamespaces, "all-namespaces", "A", false, "If true, delete the targeted resources across all namespace except kube-system")
+	cmd.Flags().StringVarP(&o.labelSelector, "selector", "l", "", "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
+	cmd.Flags().StringVar(&o.fieldSelector, "field-selector", "", "Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2). The server only supports a limited number of field queries per type.")
 	cmd.Flags().BoolVarP(&o.quiet, "quiet", "q", false, "If true, no output is produced")
 	cmd.Flags().BoolVarP(&o.interactive, "interactive", "i", false, "If true, a prompt asks whether resources can be deleted")
 	cmd.Flags().BoolVarP(&o.showVersion, "version", "v", false, "If true, show the version of this plugin")
@@ -184,9 +189,11 @@ func (o *Options) completeResources(f cmdutil.Factory, resourceTypes string) err
 		NamespaceParam(o.namespace).
 		DefaultNamespace().
 		AllNamespaces(o.allNamespaces).
+		LabelSelectorParam(o.labelSelector).
+		FieldSelectorParam(o.fieldSelector).
+		SelectAllParam(o.labelSelector == "" && o.fieldSelector == "").
 		ResourceTypeOrNameArgs(false, resourceTypes).
 		RequestChunksOf(o.chunkSize).
-		SelectAllParam(true).
 		Flatten().
 		Do()
 


### PR DESCRIPTION
Added `-l|--selector` and `--field-selector` flags.

```console
$ kubectl create cm test-cm-1 --from-literal=key=val
configmap/test-cm-1 created

$ kubectl create cm test-cm-2 --from-literal=key=val
configmap/test-cm-2 created

$ kubectl label cm test-cm-1 app=dev
configmap/test-cm-1 labeled

$ kubectl label cm test-cm-2 app=prod
configmap/test-cm-2 labeled

$ kubectl get po
No resources found in default namespace.

$ kubectl prune cm --dry-run
configmap/test-cm-1 deleted (dry run)
configmap/test-cm-2 deleted (dry run)

$ kubectl prune cm -l app=dev --dry-run=client
configmap/test-cm-1 deleted (dry run)

```