### PR TITLE
Add Job support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@
 
 Supported resources:
 
+- [x] Pods (whose status is not `Running`)
 - [x] ConfigMaps (not used in any Pods)
 - [x] Secrets (not used in any Pods or ServiceAccounts)
-- [x] Pods (whose status is not `Running`)
 - [x] PersistentVolumes (not satisfying any PersistentVolumeClaims)
 - [x] PersistentVolumeClaims (not used in any Pods)
+- [x] Jobs (completed)
 - [x] PodDisruptionBudgets (not targeting any Pods)
 - [x] HorizontalPodAutoscalers (not targeting any resources)
 
@@ -123,11 +124,12 @@ $ kubectl prune --help
 
 Delete unused resources. Supported resources:
 
+- Pods (whose status is not Running)
 - ConfigMaps (not used in any Pods)
 - Secrets (not used in any Pods or ServiceAccounts)
-- Pods (whose status is not Running)
 - PersistentVolumes (not satisfying any PersistentVolumeClaims)
 - PersistentVolumeClaims (not used in any Pods)
+- Jobs (completed)
 - PodDisruptionBudgets (not targeting any Pods)
 - HorizontalPodAutoscalers (not targeting any resources)
 

--- a/pkg/cmd/cmd.go
+++ b/pkg/cmd/cmd.go
@@ -28,6 +28,19 @@ import (
 )
 
 const (
+	pruneShortDescription = `
+Delete unused resources. Supported resources:
+
+- Pods (whose status is not Running)
+- ConfigMaps (not used in any Pods)
+- Secrets (not used in any Pods or ServiceAccounts)
+- PersistentVolumes (not satisfying any PersistentVolumeClaims)
+- PersistentVolumeClaims (not used in any Pods)
+- Jobs (completed)
+- PodDisruptionBudgets (not targeting any Pods)
+- HorizontalPodAutoscalers (not targeting any resources)
+`
+
 	pruneExample = `
   # Delete ConfigMaps not mounted on any Pods and in the current namespace and context
   $ kubectl prune configmaps
@@ -40,18 +53,6 @@ const (
 
   # Delete Pods whose status is not Running as client-side dry-run
   $ kubectl prune po --dry-run=client`
-
-	pruneShortDescription = `
-Delete unused resources. Supported resources:
-
-- ConfigMaps (not used in any Pods)
-- Secrets (not used in any Pods or ServiceAccounts)
-- Pods (whose status is not Running)
-- PersistentVolumes (not satisfying any PersistentVolumeClaims)
-- PersistentVolumeClaims (not used in any Pods)
-- PodDisruptionBudgets (not targeting any Pods)
-- HorizontalPodAutoscalers (not targeting any resources)
-`
 
 	// printedOperationTypeDeleted is used when printer outputs the result of operations.
 	printedOperationTypeDeleted = "deleted"

--- a/pkg/determiner/determiner.go
+++ b/pkg/determiner/determiner.go
@@ -120,6 +120,9 @@ func (d *determiner) DetermineDeletion(ctx context.Context, info *cliresource.In
 	case resource.KindPersistentVolumeClaim:
 		return d.determineDeletionPersistentVolumeClaim(info)
 
+	case resource.KindJob:
+		return d.determineDeletionJob(info)
+
 	case resource.KindPodDisruptionBudget:
 		return d.determineDeletionPodDisruptionBudget(info)
 
@@ -167,6 +170,15 @@ func (d *determiner) determineDeletionPersistentVolume(info *cliresource.Info) (
 func (d *determiner) determineDeletionPersistentVolumeClaim(info *cliresource.Info) (bool, error) {
 	_, ok := d.usedPersistentVolumeClaims[info.Name]
 	return !ok, nil
+}
+
+func (d *determiner) determineDeletionJob(info *cliresource.Info) (bool, error) {
+	job, err := resource.ObjectToJob(info.Object)
+	if err != nil {
+		return false, err
+	}
+
+	return job.Status.CompletionTime != nil, nil
 }
 
 func (d *determiner) determineDeletionPodDisruptionBudget(info *cliresource.Info) (bool, error) {

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -14,6 +15,7 @@ const (
 	KindServiceAccount          = "ServiceAccount"
 	KindPersistentVolume        = "PersistentVolume"
 	KindPersistentVolumeClaim   = "PersistentVolumeClaim"
+	KindJob                     = "Job"
 	KindPodDisruptionBudget     = "PodDisruptionBudget"
 	KindHorizontalPodAutoscaler = "HorizontalPodAutoscaler"
 )
@@ -46,6 +48,20 @@ func ObjectToPersistentVolume(obj runtime.Object) (*corev1.PersistentVolume, err
 	}
 
 	return &volume, nil
+}
+
+func ObjectToJob(obj runtime.Object) (*batchv1.Job, error) {
+	u, err := toUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	var job batchv1.Job
+	if err := fromUnstructured(u, &job); err != nil {
+		return nil, err
+	}
+
+	return &job, nil
 }
 
 func ObjectToPodDisruptionBudget(obj runtime.Object) (*policyv1beta1.PodDisruptionBudget, error) {


### PR DESCRIPTION
This PR allows this plugin to delete completed Jobs.

```console
$ kubectl get job
NAME     COMPLETIONS   DURATION   AGE
job-1     3/3           60s        60s
job-2     0/3           10s        10s

$ kubectl prune job
job.batch/job-1 deleted
```